### PR TITLE
Tooling: adds examples of scripting with docker/jekyll

### DIFF
--- a/.bin/crstart
+++ b/.bin/crstart
@@ -1,0 +1,9 @@
+#!/bin/sh
+#_chromium=${$_CHROMIUM:-"$(which chromium)"}
+# set CHROME_USER_DATA_DIR to persistent profile (with separate theme)
+# or:   --user-data-dir=$CHROME_USER_DATA_DIR
+
+cr_window_name=makeroanoke
+url=${1:-"http://localhost:4000"}
+#$_chromium --window-name=$cr_window_name
+nohup chromium --window-name=$cr_window_name $url 2>&1 >/dev/null &

--- a/.bin/jstart
+++ b/.bin/jstart
@@ -1,0 +1,15 @@
+#!/bin/sh
+#_path=${1:-$PWD}
+_path=$(pwd)
+if [ $# -gt 0 ]; then
+    _path=$_path/$1
+    shift 1
+fi
+
+# or run: `docker compose --env-file .jekyll.env up` to change the ports
+_command="bundle exec jekyll serve --force_polling -H 0.0.0.0 -P 4000 --livereload"
+_image=bretfisher/jekyll-serve:alpine
+docker run -it --rm \
+       -p 4000:4000 -p 35729:35729 \
+       -v "$_path:/site" $_image \
+       $_command $@

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ _site
 .jekyll-cache
 .jekyll-metadata
 vendor
+docker-compose.yml
+.env

--- a/doc/scripts.md
+++ b/doc/scripts.md
@@ -1,0 +1,58 @@
+
+# Docker
+
+`jstart` starts jekyll in docker with `--livereload`. The first argument will specify a separate relative path for the mounted volume.
+
+## Jekyll Environment
+
+The following environment variables are referenced in jekyll's source:
+
++ JEKYLL_ENV
++ JEKYLL_LOG_LEVEL
++ JEKYLL_NO_BUNDLER_REQUIRE
++ BUNDLE_GEMFILE
++ TZ
++ DEBUG
+
+## Compose
+
+Copy `docker-compose.eg.yml` to `docker-compose.yml` for a basic config
+
+### Multiple Jekyll Instances
+
+To start, run:
+
+```sh
+docker compose -f docker-compose.jekyll.yml --env-file .jekyll.env up
+```
+
+`.env` file format:
+
+```sh
+_JEKYLL_PORT=4001
+_JEKYLL_LIVE_RELOAD=35729
+```
+
+Docker compose file:
+
+```yaml
+---
+version: "3.8"
+services:
+  jekyll:
+    image: "bretfisher/jekyll-serve:alpine"
+    command: "bundle exec jekyll serve --force_polling -H 0.0.0.0 -P ${_JEKYLL_PORT} --livereload --livereload-port ${_JEKYLL_LIVE_RELOAD} $@"
+    ports:
+      - "${_JEKYLL_PORT}:${_JEKYLL_PORT}"
+      - "${_JEKYLL_LIVE_RELOAD}:${_JEKYLL_LIVE_RELOAD}"
+    volumes:
+      - './site:/site'
+```
+
+This is mostly useful when using `git worktree`, but that requires a lot of setup. Also, each branch to have its own git-ignored files like `.vscode`. `docker-compose.yml` or `node_modules`.
+
+# Chromium
+
+`crstart` starts a chromium browser with the window name set to `makeroanoke`.
+
+The script will launch chrome with a custom profile if `CHROME_USER_DATA` is set. This allows you to apply custom settings like a distinct theme, making the window easier to spot.

--- a/docker-compose.eg.yml
+++ b/docker-compose.eg.yml
@@ -1,0 +1,11 @@
+---
+version: "3.8"
+services: 
+  jekyll: 
+    image: "bretfisher/jekyll-serve:alpine"
+    command: "bundle exec jekyll serve --force_polling -H 0.0.0.0 -P 4000 --livereload $@"
+    ports:
+      - 4000:4000
+      - 35729:35729
+    volumes:
+      - './site:/site'


### PR DESCRIPTION
I wasn't sure whether I should push this up, but I thought it might help later on.