### PR TITLE
Docs: add notes on vscode and git

### DIFF
--- a/doc/git.md
+++ b/doc/git.md
@@ -1,0 +1,42 @@
+
+# Git
+
+## Git Config
+
+For anyone learning git, these links should help:
+
++ [githubtraining/advanced-git](https://github.com/githubtraining/advanced-git/tree/master).
++ [Git Cheat Sheets](https://github.com/githubtraining/advanced-git/tree/master)
+
+The first link explains `git rerere` further.
+
+### Simple Config to Prevent Local Merge Conflicts
+
+In particular, there are these two settings which help avoid merge conflicts. 
+
++ With small branches covering many files, merge conflicts may happen often. 
++ When a branch just adds a post that's rarely edited, merge conflicts are unlikely.
+
+Still, they could occasionally block Jekyll or add characters to the HTML, which could be frustrating.
+
+**git rebase**
+
+When your `git pull` command is set to `rebase` it avoids merge conflicts when you update your local copy with upstream changes. It's set to `merge` by default.
+
+Running `git config --global pull.rebase true` will default to rebase when pulling.
+
+**git rerere**
+
+Also, `git rerere` will remember the merge resolution for conflicts you encounter and will replay the same resolution in the future. 
+
+Enable it by running `git config --global rerere.enabled true`.
+
+The commands should set the following in your `~/.gitconfig`
+
+```toml
+[pull]
+	rebase = true
+
+[rerere]
+	enabled = true
+```

--- a/doc/vscode.md
+++ b/doc/vscode.md
@@ -1,9 +1,23 @@
+
+# Browsers
+
+## Chromium
+
+The [keyboard shortcuts](https://developer.chrome.com/docs/devtools/shortcuts) for Chromium's DevTools provide a good survey of the features available.
+
+### Visbug
+
+[Visbug](https://chromewebstore.google.com/detail/visbug/cdockenadnadldjbbgcallicgledbeoc) is a Chrome extension that allows you to more easily grok the DOM. You can do things like measure distances between elements, change colors, save changes to page. You can test the extension's features in [visbug.web.app](https://visbug.web.app/)
+
+## Firefox
+
+An overview of the Firefox DevTools feature set can be found in their docs on [shortcut keys](https://firefox-source-docs.mozilla.org/devtools-user/keyboard_shortcuts/index.html#keyboard-shortcuts-opening-and-closing-tools).
+
 # VSCode
 
 ## Extensions
 
-If an extension is found in the `.vscode/recommended.json`, we've tested that
-it's generally compatible with other extensions in that file.
+If an extension is found in the `.vscode/recommended.json`, we've tested that it's generally compatible with other extensions in that file.
 
 ### Frontend
 
@@ -14,11 +28,8 @@ it's generally compatible with other extensions in that file.
 |     vscode-yaml |   redhat.vscode-yaml   | Quickly checks the format of Jekyll's `_config.yml` for you      |
 |          liquid | sissel.shopify-liquid  |                                                                  |
 
-- `vscode-yaml` may require configuring the [Jekyll YAML
-  schema](https://json.schemastore.org/jekyll), but it should autodownload once
-  it's set.
-- `vscode-thunder-client`: allows you to test making requests to API's. It may
-  be helpful when working on automation later.
+- `vscode-yaml` may require configuring the [Jekyll YAML schema](https://json.schemastore.org/jekyll), but it should autodownload once it's set.
+- `vscode-thunder-client`: allows you to test making requests to API's. It may be helpful when working on automation later.
 
 #### Liquid
 
@@ -30,8 +41,7 @@ To make the liquid extension work, see [the response on this post](https://talk.
 
 #### YAML
 
-To enable parsing of YAML for Jekyll and Docker Compose, your `.vscode/extensions.json` file
-should contain at least `yaml.schemas`.
+To enable parsing of YAML for Jekyll and Docker Compose, your `.vscode/extensions.json` file should contain at least `yaml.schemas`.
 
 The schema association for a YAML file can be set in a file-local variable. See [Associating Schemas](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml).
 
@@ -56,10 +66,8 @@ The schema association for a YAML file can be set in a file-local variable. See 
 
 ### Git
 
-- Gitlens is an alternative to git-graph, but is more likely to impact performance. 
-  When GitLens is used, the other four extensions below should be disabled or deleted.
-- With `vscode-pull-request-github`, you can manage the Github project from
-  VSCode to create or respond to pull requests and issues.
+- Gitlens is an alternative to git-graph, but is more likely to impact performance. When GitLens is used, the other four extensions below should be disabled or deleted.
+- With `vscode-pull-request-github`, you can manage the Github project from VSCode to create or respond to pull requests and issues.
 
 |      name |           key           | description                                                              |
 | --------: | :---------------------: | :----------------------------------------------------------------------- |
@@ -70,15 +78,13 @@ The schema association for a YAML file can be set in a file-local variable. See 
 
 Other Git Extensions
 
-- I you're new to git: `git-graph`, `gitstash` and perhaps `gitignore` may be
-  useful
+- I you're new to git: `git-graph`, `gitstash` and perhaps `gitignore` may be useful
 - `vscode-conventional-commits` may be helpful to format commits (IDK)
 - `vscode-gitweblinks` can help to quickly communicate about code
 
 ### Docs
 
-The `manpages` extension allows you to open docs from `man` for entries it finds
-in your `MANPATH`.
+The `manpages` extension allows you to open docs from `man` for entries it finds in your `MANPATH`.
 
 ### Future Extensions
 
@@ -91,11 +97,10 @@ in your `MANPATH`.
 
 ### Emmet
 
-EmmetCSS is included by default. It allows you to type abbreviated CSS selectors
-and have them expand into DOM.
+EmmetCSS is included by default. It allows you to type abbreviated CSS selectors and have them expand into DOM. It also works for XML.
 
 - How to use [Emmet HTML/CSS Snippets](https://code.visualstudio.com/docs/editor/emmet)
-- TODO: Emmet Cheatsheet: altogether a great reference for HTML5 and CSS3.
+- [Emmet Cheatsheet](https://docs.emmet.io/cheat-sheet/): altogether a great reference for HTML5 and CSS3. The cheatsheet includes information on flexbox, but not CSS3 grids.
 
 ### Completion and Documentation
 
@@ -104,11 +109,6 @@ configuration.
 
 ### Formatting and Linting
 
-The `prettier` and `eslint` extensions are particularly helpfu, but may require
-running `npm install -g $pkg`. They mainly make pull requests much smaller and
-and simpler, especially for javascript. Extremely helpful, but if these tools
-aren't working in your environment, it's not worthwhile in this project.
+The `prettier` and `eslint` extensions are particularly helpfu, but may require running `npm install -g $pkg`. They mainly make pull requests much smaller and and simpler, especially for javascript. Extremely helpful, but if these tools aren't working in your environment, it's not worthwhile in this project.
 
-Combining them may require
-[prettier-eslint](https://www.npmjs.com/package/prettier-eslint). It would be
-simpler to just disable eslint, especially if you're not writing javascript.
+Combining them may require [prettier-eslint](https://www.npmjs.com/package/prettier-eslint). It would be simpler to just disable eslint, especially if you're not writing javascript.

--- a/doc/vscode.md
+++ b/doc/vscode.md
@@ -1,0 +1,114 @@
+# VSCode
+
+## Extensions
+
+If an extension is found in the `.vscode/recommended.json`, we've tested that
+it's generally compatible with other extensions in that file.
+
+### Frontend
+
+|            name |          key           | description                                                      |
+| --------------: | :--------------------: | :--------------------------------------------------------------- |
+| prettier-vscode | esbenp.prettier-vscode | Autoformats html, css/scss/less, javascript/json, markdown, yaml |
+|   vscode-eslint | dbaeumer.vscode-eslint | Cleans code, catches simple mistakes and adds missing semicolons |
+|     vscode-yaml |   redhat.vscode-yaml   | Quickly checks the format of Jekyll's `_config.yml` for you      |
+|          liquid | sissel.shopify-liquid  |                                                                  |
+
+- `vscode-yaml` may require configuring the [Jekyll YAML
+  schema](https://json.schemastore.org/jekyll), but it should autodownload once
+  it's set.
+- `vscode-thunder-client`: allows you to test making requests to API's. It may
+  be helpful when working on automation later.
+
+#### Liquid
+
+[Liquid extension](https://github.com/panoply/vscode-liquid)
+
+A `.liquidrc` file needs to be present and a generator can be found in the command pallette. The engine should be set to `standard`.
+
+To make the liquid extension work, see [the response on this post](https://talk.jekyllrb.com/t/jekyll-liquid-visual-studio-code/5531/6)
+
+#### YAML
+
+To enable parsing of YAML for Jekyll and Docker Compose, your `.vscode/extensions.json` file
+should contain at least `yaml.schemas`.
+
+The schema association for a YAML file can be set in a file-local variable. See [Associating Schemas](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml).
+
+```json
+{
+  "yaml.format.enable": true,
+  "yaml.format.singleQuote": null,
+  "yaml.format.bracketSpacing": true,
+  "yaml.format.proseWrap": "preserve",
+  "yaml.format.printWidth": 80,
+  "yaml.validate": true,
+  "yaml.hover": true,
+  "yaml.completion": true,
+  "yaml.schemas": {
+    "https://json.schemastore.org/jekyll": "site/_config.yml",
+    "https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json": "/docker-compose.*.yml"
+  },
+  "yaml.customTags": null,
+  "yaml.maxItemsComputed": 5000
+}
+```
+
+### Git
+
+- Gitlens is an alternative to git-graph, but is more likely to impact performance. 
+  When GitLens is used, the other four extensions below should be disabled or deleted.
+- With `vscode-pull-request-github`, you can manage the Github project from
+  VSCode to create or respond to pull requests and issues.
+
+|      name |           key           | description                                                              |
+| --------: | :---------------------: | :----------------------------------------------------------------------- |
+| git-graph |   mhutchie.git-graph    | Shows git history to help you navigate branches and check changesets     |
+|  gitstash |    arturock.gitstash    | Quickly "stash" and "unstash" changes to pull updates or change branches |
+| git-blame | solomonkinard.git-blame | Shows where a line of code came from and what's in the same commit       |
+|  gitpatch |   paragdiwan.gitpatch   | Advanced tool for contributing to projects with email-based workflows    |
+
+Other Git Extensions
+
+- I you're new to git: `git-graph`, `gitstash` and perhaps `gitignore` may be
+  useful
+- `vscode-conventional-commits` may be helpful to format commits (IDK)
+- `vscode-gitweblinks` can help to quickly communicate about code
+
+### Docs
+
+The `manpages` extension allows you to open docs from `man` for entries it finds
+in your `MANPATH`.
+
+### Future Extensions
+
+#### Tailwind CSS
+
++ bradlc.vscode-tailwindcss
++ csstools.postcss
+
+## Web development
+
+### Emmet
+
+EmmetCSS is included by default. It allows you to type abbreviated CSS selectors
+and have them expand into DOM.
+
+- How to use [Emmet HTML/CSS Snippets](https://code.visualstudio.com/docs/editor/emmet)
+- TODO: Emmet Cheatsheet: altogether a great reference for HTML5 and CSS3.
+
+### Completion and Documentation
+
+All the Web Development LSP should just work (HTML/CSS/JS), but may require some
+configuration.
+
+### Formatting and Linting
+
+The `prettier` and `eslint` extensions are particularly helpfu, but may require
+running `npm install -g $pkg`. They mainly make pull requests much smaller and
+and simpler, especially for javascript. Extremely helpful, but if these tools
+aren't working in your environment, it's not worthwhile in this project.
+
+Combining them may require
+[prettier-eslint](https://www.npmjs.com/package/prettier-eslint). It would be
+simpler to just disable eslint, especially if you're not writing javascript.


### PR DESCRIPTION
I started this thinking that a `docs/vscode.md` would be more geared towards
setting up vscode for non-technical users.

I may be presumptuous in writing most of this out and I don't know if we'll need
all these features.

## Git

The notes on git are essential for avoiding merge conflicts, IMO.

## VSCode

The notes on VSCode need some work. I haven't used these extensions much.

### Prettier/ESLint

This is really probably overkill.

### GitLens

Preferable to the other four, if many of its features are turned off. the
git-blame annotations are way too much IMO

### Liquid

I haven't quite gotten this to work. It understands liquid, but doesn't quite
understand where Jekyll's templates are AFAIK. If that doesn't work, most of the
value in a basic configuration comes down to whether liquid templates impact the
functionality of what is otherwise mostly HTML/JSON.

This may be irrelevant if we use something like front-matter.

### YAML

This /can/ help for jekyll, but Dash app has docs on Jekyll (zeal on linux)

### CSS

This is mostly native, but may require notes on configuration later.