### PR TITLE
Adding link to facebook

### DIFF
--- a/site/_includes/contact-list.html
+++ b/site/_includes/contact-list.html
@@ -12,7 +12,9 @@
     <li>{% include icon-github.html username=site.github_username label='GitHub' %}</li>
   {% endif %}
 
-    <li>{% include icon-instagram.html username='make_roanoke' label='Instagram' %}</li>
+  <li>{% include icon-instagram.html username='make_roanoke' label='Instagram' %}</li>
+
+  <li>{% include icon-facebook.html username='profile.php?id=61555003782595' label='Facebook' %}</li>
 
   {% if site.twitter_username %}
     <li>{% include icon-twitter.html username=site.twitter_username label='Twitter' %}</li>


### PR DESCRIPTION
The following change adds the facebook link inside the contact list, which will appear in the menu.