### PR TITLE
First meeting announcement, with hidden calendar and updated timing on events pages

### DIFF
--- a/site/_includes/page-intro.html
+++ b/site/_includes/page-intro.html
@@ -1,0 +1,49 @@
+<header class="intro">
+  {% if page.image %}
+    {% assign intro_image = page.image.path | default: page.image | relative_url | escape %}
+    <div class="intro-image">
+      <img src="{{ intro_image }}" alt="{{ page.title }}">
+    </div>
+  {% endif %}
+
+  <div class="inner">
+    <div class="intro-text">
+      <h1 id="page-title" class="intro-title">{{ page.alt_title | default: page.title | default: site.title | markdownify | strip_html }}</h1>
+      {% if page.sub_title %}
+        <p class="intro-subtitle">{{ page.sub_title | markdownify | strip_html }}</p>
+      {% endif %}
+
+      {% if page.date %}
+        {% include author %}
+        <p class="entry-meta">
+          {% if author_name %}<span class="byline-item">{{ author_name | prepend: 'by ' }}</span>{% endif %}<span class="byline-item"><span class="icon">{% include icon-calendar.svg %}</span><time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time></span>
+          {% if page.event_time_start %} <span class="byline-item">
+              <span class="icon"> {% include icon-stopwatch.svg %}</span>
+              <time> {{ page.event_time_start | date: "%l:%M %p(%z)" }}</time>
+          </span>
+          {% endif %}
+          {% if page.event_time_end %}
+              <span class="icon"> {% include icon-arrow-right.svg %}</span>
+              <time> {{ page.event_time_end | date: "%l:%M %p(%z)" }}</time>
+          </span>
+          {% endif %}
+          {% if page.read_time %} <span class="byline-item"><span class="icon">{% include icon-stopwatch.svg %}</span>{% capture read_time %}{% include read-time.html %}{% endcapture %}{{ read_time | strip }}</span>{% endif %}
+        </p>
+      {% endif %}
+
+      {% if page.introduction %}
+        <div class="intro-more">
+          {{ page.introduction | markdownify }}
+        </div>
+      {% endif %}
+
+      {% if page.actions %}
+        <ul class="intro-actions">
+          {% for action in page.actions %}
+            <li><a href="{{ action.url }}" class="btn">{% if action.icon %}<span class="icon">{% include {{ action.icon | prepend: 'icon-' | append: '.svg' }} %}</span>{% endif %}{{ action.label }}</a></li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    </div>
+  </div>
+</header>

--- a/site/cal.ics
+++ b/site/cal.ics
@@ -1,0 +1,21 @@
+---
+# vim: ff=dos
+layout: null
+---
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//MAKE Roanoke//Jekyll Hacks//EN {% assign current_events = site.events | where_exp: "event", "event.date >= site.time" %} {% for event in current_events limit:3 %}
+X-WR-TIMEZONE:America/New_York
+METHOD:PUBLISH
+BEGIN:VEVENT
+UID:{{ event.event_date | date: "%Y%m%d" }}-{{event.title | slugify}}@makeroanoke.org
+ORGANIZER;CN="Information":MAILTO:info@makeroanoke.org
+LOCATION: {{event.location}}
+SUMMARY:{{ event.title | remove: ',' | remove: ';' }}
+DESCRIPTION:https://makeroanoke.org{{ event.url }}
+CLASS:PUBLIC
+DTSTART;TZID=America/New_York:{{ event.event_date | date: "%Y%m%d" }}T{{event.event_time_start | remove: ':'}}00
+DTEND;TZID=America/New_York:{{ event.event_date | date: "%Y%m%d" }}T{{event.event_time_end | remove: ':'}}00
+DTSTAMP;TZID=America/New_York:{{ event.event_date | date: "%Y%m%d" }}T{{event.event_time_start | remove: ':'}}00
+END:VEVENT{% endfor %}
+END:VCALENDAR

--- a/site/content/_events/2024-02-22-First_General_Meeting.md
+++ b/site/content/_events/2024-02-22-First_General_Meeting.md
@@ -19,9 +19,8 @@ launch our community of passionate makers.  This is your chance to:
 * **Get inside info:** Hear directly from the MAKE Roanoke founders about our
   exciting plans and what the future holds for this vibrant initiative.
 
-* **Connect with your tribe:** Introduce yourself, share your current projects,
-  and discover the incredible talents and diverse interests of your fellow
-  makers.
+* **Show us what you got:** Introduce yourself and share your current project to
+  the new MAKE Roanoke Community.
 
 * **Be inspired:** Meet other interesting MAKERs, spark ideas, and ignite your
   imagination with the possibilities of a collaborative maker community.
@@ -33,6 +32,9 @@ Whether you're a seasoned pro with a workshop full of gadgets or just starting
 out with a glue gun and boundless enthusiasm, everyone is welcome!  This is a
 space for learning, sharing, and supporting each other as we bring our unique
 ideas to life.
+
+We are excited to share with you the latest news of MAKE Roanoke, and are
+excited to see what you bring to the table!
 
 So, dust off your projects, grab your curiosity, and join us for an evening of
 making, connecting, and igniting the Roanoke innovation scene!

--- a/site/content/_events/2024-02-22-First_General_Meeting.md
+++ b/site/content/_events/2024-02-22-First_General_Meeting.md
@@ -1,0 +1,44 @@
+---
+layout: event
+title:  "First General Meeting"
+event_date:   2024-02-22
+event_time_start: "18:00"
+event_time_end: "20:00"
+location: South County Library - https://maps.app.goo.gl/wRVtCgkj5tPcuC4a7
+categories: community
+---
+
+Attention, Roanoke Makers! Calling all tinkererers, creators, and DIY dreamers!
+
+Ready to unleash your inner innovator and be part of something groundbreaking?
+Then mark your calendars, because MAKE Roanoke's first public meeting is here! ️
+
+Join us at the South County Library on February 22nd at 6 PM as we officially
+launch our community of passionate makers.  This is your chance to:
+
+* **Get inside info:** Hear directly from the MAKE Roanoke founders about our
+  exciting plans and what the future holds for this vibrant initiative.
+
+* **Connect with your tribe:** Introduce yourself, share your current projects,
+  and discover the incredible talents and diverse interests of your fellow
+  makers.
+
+* **Be inspired:** Meet other interesting MAKERs, spark ideas, and ignite your
+  imagination with the possibilities of a collaborative maker community.
+
+* **Be a part of it all:** Help shape the future of MAKE Roanoke and contribute
+  to building a space where creativity thrives.
+
+Whether you're a seasoned pro with a workshop full of gadgets or just starting
+out with a glue gun and boundless enthusiasm, everyone is welcome!  This is a
+space for learning, sharing, and supporting each other as we bring our unique
+ideas to life.
+
+So, dust off your projects, grab your curiosity, and join us for an evening of
+making, connecting, and igniting the Roanoke innovation scene!
+
+Please help us show who is coming and spread the word by showing some interest
+at the [Facebook Event Page](https://www.facebook.com/events/901879911429355)!
+
+P.S. Don't forget to share your creations and excitement on social media using
+#MAKERoanoke!

--- a/site/content/_events/2024-02-22-First_General_Meeting.md
+++ b/site/content/_events/2024-02-22-First_General_Meeting.md
@@ -34,7 +34,7 @@ space for learning, sharing, and supporting each other as we bring our unique
 ideas to life.
 
 We are excited to share with you the latest news of MAKE Roanoke, and are
-excited to see what you bring to the table!
+excited to see what you've made!
 
 So, dust off your projects, grab your curiosity, and join us for an evening of
 making, connecting, and igniting the Roanoke innovation scene!

--- a/site/content/_events/2024-03-02-raspberry_pi_jam.md
+++ b/site/content/_events/2024-03-02-raspberry_pi_jam.md
@@ -2,8 +2,8 @@
 layout: event
 title:  "2024 Raspberry Pi Jam"
 event_date:   2024-03-02
-event_time_start: 10:00
-event_time_end: 13:00
+event_time_start: "10:00"
+event_time_end: "13:00"
 location: South County Library - https://maps.app.goo.gl/wRVtCgkj5tPcuC4a7
 categories: community
 ---

--- a/site/content/_events/2024-03-24-lynchburg_maker_faire.md
+++ b/site/content/_events/2024-03-24-lynchburg_maker_faire.md
@@ -1,9 +1,9 @@
 ---
 layout: event
 title: "2024 Maker Faire Lynchburg"
-event_date: 2024-03-26
-event_time_start: 11:00
-event_time_end: 16:00
+event_date: 2024-03-24
+event_time_start: "11:00"
+event_time_end: "16:00"
 location: 2500 Rivermont Avenue in Lynchburg, Virginia
 categories: community
 ---

--- a/site/content/_posts/2024-01-31-first_general_meeting.md
+++ b/site/content/_posts/2024-01-31-first_general_meeting.md
@@ -1,0 +1,42 @@
+---
+layout: post
+title:  "First Public Meeting"
+date:   2024-01-31
+location: South County Library - https://maps.app.goo.gl/wRVtCgkj5tPcuC4a7
+categories: community
+---
+
+Attention, Roanoke Makers! Calling all tinkererers, creators, and DIY dreamers!
+
+Ready to unleash your inner innovator and be part of something groundbreaking?
+Then mark your calendars, because MAKE Roanoke's first public meeting is here! ️
+
+Join us at the South County Library on February 22nd at 6 PM as we officially
+launch our community of passionate makers.  This is your chance to:
+
+* **Get inside info:** Hear directly from the MAKE Roanoke founders about our
+  exciting plans and what the future holds for this vibrant initiative.
+
+* **Connect with your tribe:** Introduce yourself, share your current projects,
+  and discover the incredible talents and diverse interests of your fellow
+  makers.
+
+* **Be inspired:** Meet other interesting MAKERs, spark ideas, and ignite your
+  imagination with the possibilities of a collaborative maker community.
+
+* **Be a part of it all:** Help shape the future of MAKE Roanoke and contribute
+  to building a space where creativity thrives.
+
+Whether you're a seasoned pro with a workshop full of gadgets or just starting
+out with a glue gun and boundless enthusiasm, everyone is welcome!  This is a
+space for learning, sharing, and supporting each other as we bring our unique
+ideas to life.
+
+So, dust off your projects, grab your curiosity, and join us for an evening of
+making, connecting, and igniting the Roanoke innovation scene!
+
+Please help us show who is coming and spread the word by showing some interest
+at the [Facebook Event Page](https://www.facebook.com/events/901879911429355)!
+
+P.S. Don't forget to share your creations and excitement on social media using
+#MAKERoanoke!

--- a/site/content/_posts/2024-01-31-first_general_meeting.md
+++ b/site/content/_posts/2024-01-31-first_general_meeting.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "First Public Meeting"
+title:  "First Public Meeting: February 22, 2024"
 date:   2024-01-31
 location: South County Library - https://maps.app.goo.gl/wRVtCgkj5tPcuC4a7
 categories: community

--- a/site/content/_posts/2024-01-31-first_general_meeting.md
+++ b/site/content/_posts/2024-01-31-first_general_meeting.md
@@ -17,9 +17,8 @@ launch our community of passionate makers.  This is your chance to:
 * **Get inside info:** Hear directly from the MAKE Roanoke founders about our
   exciting plans and what the future holds for this vibrant initiative.
 
-* **Connect with your tribe:** Introduce yourself, share your current projects,
-  and discover the incredible talents and diverse interests of your fellow
-  makers.
+* **Show us what you got:** Introduce yourself and share your current project to
+  the new MAKE Roanoke Community.
 
 * **Be inspired:** Meet other interesting MAKERs, spark ideas, and ignite your
   imagination with the possibilities of a collaborative maker community.
@@ -31,6 +30,9 @@ Whether you're a seasoned pro with a workshop full of gadgets or just starting
 out with a glue gun and boundless enthusiasm, everyone is welcome!  This is a
 space for learning, sharing, and supporting each other as we bring our unique
 ideas to life.
+
+We are excited to share with you the latest news of MAKE Roanoke, and are
+excited to see what you bring to the table!
 
 So, dust off your projects, grab your curiosity, and join us for an evening of
 making, connecting, and igniting the Roanoke innovation scene!

--- a/site/content/_posts/2024-01-31-first_general_meeting.md
+++ b/site/content/_posts/2024-01-31-first_general_meeting.md
@@ -32,7 +32,7 @@ space for learning, sharing, and supporting each other as we bring our unique
 ideas to life.
 
 We are excited to share with you the latest news of MAKE Roanoke, and are
-excited to see what you bring to the table!
+excited to see what you've made!
 
 So, dust off your projects, grab your curiosity, and join us for an evening of
 making, connecting, and igniting the Roanoke innovation scene!


### PR DESCRIPTION
It effectively:
* Creates a post and event for first meeting
* Updates page layout to including timing information if a page has event_time_start and event_time_end.  It's not pretty, but it works for now.
* Includes a hidden .ics file for testing.  It's not 100%, but works.  It should show the next 3 upcoming events for now.